### PR TITLE
feat(pe): admin compensation & incident logging (csv persistence + lightweight API)

### DIFF
--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/AdminCompensation.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/AdminCompensation.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Text;
+
+namespace PEEnhancements
+{
+    /// <summary>
+    /// MVP: Schreibt Kompensations-Aufträge in eine CSV-Queue + Log.
+    /// Die tatsächliche Item-/Gold-Ausgabe hängt an eurem existierenden Inventar-/Banking-API
+    /// und kann über einen Callback integriert werden.
+    /// </summary>
+    public static class AdminCompensation
+    {
+        public delegate bool GrantHandler(string playerId, string itemId, int amount, string reason);
+
+        /// <summary>
+        /// Optionaler Hook: Wenn gesetzt, wird reale Ausgabe versucht; sonst nur CSV-Queue.
+        /// </summary>
+        public static GrantHandler? OnGrant;
+
+        private static string _queuePath = string.Empty;
+        private static string _logPath = string.Empty;
+        private static readonly ConcurrentQueue<string> _pending = new();
+
+        public static void Init(string moduleRoot)
+        {
+            var logDir = Path.Combine(moduleRoot, "Logs");
+            Directory.CreateDirectory(logDir);
+            _queuePath = Path.Combine(logDir, "pe.compensations.todo.csv");
+            _logPath = Path.Combine(logDir, "pe.compensations.done.csv");
+        }
+
+        public static bool Request(string adminId, string playerId, string itemId, int amount, string reason)
+        {
+            var line = $"{DateTime.UtcNow:O};{adminId};{playerId};{itemId};{amount};{reason}";
+            _pending.Enqueue(line);
+            FlushQueue();
+
+            if (OnGrant != null)
+            {
+                try
+                {
+                    var ok = OnGrant(playerId, itemId, amount, reason);
+                    File.AppendAllText(_logPath, $"{line};granted={ok}\\n", Encoding.UTF8);
+                    return ok;
+                }
+                catch (Exception e)
+                {
+                    File.AppendAllText(_logPath, $"{line};error={e.Message}\\n", Encoding.UTF8);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static void FlushQueue()
+        {
+            if (string.IsNullOrEmpty(_queuePath))
+            {
+                return;
+            }
+
+            using var sw = new StreamWriter(_queuePath, append: true, Encoding.UTF8);
+            while (_pending.TryDequeue(out var line))
+            {
+                sw.WriteLine(line);
+            }
+        }
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/AdminKulanzBehavior.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/AdminKulanzBehavior.cs
@@ -1,0 +1,47 @@
+using System;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace PEEnhancements
+{
+    /// <summary>
+    /// MissionBehavior, das lediglich die Admin-Services initialisiert.
+    /// Chat-/Slash-Command-Parsing ist projektspezifisch – hier nicht erzwungen.
+    /// </summary>
+    public class AdminKulanzBehavior : MissionLogic
+    {
+        public static AdminKulanzBehavior? Instance { get; private set; }
+
+        public override void OnBehaviorInitialize()
+        {
+            base.OnBehaviorInitialize();
+            Instance = this;
+        }
+
+        public override void AfterStart()
+        {
+            base.AfterStart();
+            try
+            {
+                var root = TaleWorlds.ModuleManager.ModuleHelper.GetModuleFullPath("PersistentEmpires");
+                AdminCompensation.Init(root);
+                IncidentLogger.Init(root);
+            }
+            catch (Exception e)
+            {
+                Debug.Print("[PEEnhancements] Admin init failed: " + e.Message);
+            }
+        }
+
+        // --- Public API, z.B. aufrufbar aus eurem ChatCommand-Handler ---
+        public bool Compensate(string adminId, string playerId, string itemId, int amount, string reason)
+        {
+            return AdminCompensation.Request(adminId, playerId, itemId, amount, reason);
+        }
+
+        public void IncidentNote(string reporterId, string incidentId, string clipUrl, string note)
+        {
+            IncidentLogger.Append(reporterId, incidentId, clipUrl, note);
+        }
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/IncidentLogger.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/IncidentLogger.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace PEEnhancements
+{
+    /// <summary>
+    /// MVP-Incident-Logger mit CSV-Ausgabe (UTC-Zeitstempel).
+    /// </summary>
+    public static class IncidentLogger
+    {
+        private static string _path = string.Empty;
+
+        public static void Init(string moduleRoot)
+        {
+            var logDir = Path.Combine(moduleRoot, "Logs");
+            Directory.CreateDirectory(logDir);
+            _path = Path.Combine(logDir, "pe.incidents.csv");
+            if (!File.Exists(_path))
+            {
+                File.WriteAllText(_path, "timestamp;reporterId;incidentId;clipUrl;note\n", Encoding.UTF8);
+            }
+        }
+
+        public static void Append(string reporterId, string incidentId, string clipUrl, string note)
+        {
+            if (string.IsNullOrEmpty(_path))
+            {
+                return;
+            }
+
+            var line = $"{DateTime.UtcNow:O};{reporterId};{incidentId};{clipUrl};{note}".Replace('\n', ' ').Replace('\r', ' ');
+            File.AppendAllText(_path, line + "\n", Encoding.UTF8);
+        }
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PersistentEmpiresMission/MissionBehaviors/AgentHungerBehavior.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PersistentEmpiresMission/MissionBehaviors/AgentHungerBehavior.cs
@@ -176,6 +176,19 @@ namespace PersistentEmpiresLib.PersistentEmpiresMission.MissionBehaviors
             {
                 Mission.Current?.AddMissionBehavior(new PEEnhancements.HuntingDropFilterBehavior());
             }
+            if (PEEnhancements.PropertySystem.Instance == null)
+            {
+                Mission.Current?.AddMissionBehavior(new PEEnhancements.PropertySystem());
+            }
+            if (PEEnhancements.PropertyMvpBehavior.Instance == null)
+            {
+                Mission.Current?.AddMissionBehavior(new PEEnhancements.PropertyMvpBehavior());
+            }
+            // Admin/Incidents initialisieren
+            if (PEEnhancements.AdminKulanzBehavior.Instance == null)
+            {
+                Mission.Current?.AddMissionBehavior(new PEEnhancements.AdminKulanzBehavior());
+            }
         }
 #endif
 


### PR DESCRIPTION
## Summary
- add CSV-backed admin compensation queue with optional grant hook
- provide incident logger with CSV export and mission behavior bootstrap
- register admin tooling mission behavior during mission tick

## Testing
- `dotnet build PersistentEmpiresLib/PersistentEmpiresLib/PersistentEmpiresLib.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cd2e3543648332a1927846bd7b42f4