### PR TITLE
Improve SQL integration for player persistence

### DIFF
--- a/PersistentEmpiresServer/PersistentEmpiresSave/Database/DBConnection.cs
+++ b/PersistentEmpiresServer/PersistentEmpiresSave/Database/DBConnection.cs
@@ -2,24 +2,71 @@
 using MySqlConnector;
 using PersistentEmpiresLib.Database.DBEntities;
 using PersistentEmpiresSave.Database.Helpers;
+using System;
+using System.Data;
 using System.Data.Common;
 
 namespace PersistentEmpiresSave.Database
 {
     public class DBConnection
     {
-        public static DbConnection Connection = null;
+        private static readonly object ConnectionLock = new object();
+        private static string _connectionString = string.Empty;
+        private static MySqlConnection _connection;
 
+        public static DbConnection Connection
+        {
+            get
+            {
+                EnsureConnection();
+                return _connection;
+            }
+        }
 
         public static void InitializeSqlConnection(string DbConnectionString)
         {
             SqlMapper.AddTypeHandler(new JsonTypeHandler<AffectedPlayer[]>());
-            DBConnection.Connection = new MySqlConnection(DbConnectionString);
+            lock (ConnectionLock)
+            {
+                _connection?.Dispose();
+                _connection = null;
+                _connectionString = DbConnectionString;
+            }
         }
 
         public static void ExecuteDapper(string query, object param)
         {
             Connection.Execute(query, param);
+        }
+
+        private static void EnsureConnection()
+        {
+            if (string.IsNullOrEmpty(_connectionString))
+            {
+                throw new InvalidOperationException("SQL connection has not been initialised.");
+            }
+
+            if (_connection != null && _connection.State == System.Data.ConnectionState.Open)
+            {
+                return;
+            }
+
+            lock (ConnectionLock)
+            {
+                if (_connection != null)
+                {
+                    if (_connection.State == System.Data.ConnectionState.Open)
+                    {
+                        return;
+                    }
+
+                    _connection.Dispose();
+                    _connection = null;
+                }
+
+                _connection = new MySqlConnection(_connectionString);
+                _connection.Open();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure the database helper tracks the configured connection string and reopens the shared MySQL connection when required
- replace string-built player upsert statements with a parameterised query, shared helpers, and structured logging snapshots

## Testing
- dotnet build PersistentEmpiresServer/PersistentEmpiresServer.sln *(fails: dotnet command is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd2f88ab5483329a59cf9c837da6f1