### PR TITLE
feat(pe): tavern prompts and barkeep shift system

### DIFF
--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepShiftBehavior.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepShiftBehavior.cs
@@ -1,0 +1,66 @@
+using System;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace PEEnhancements.Economy
+{
+    /// <summary>
+    /// Mission wrapper that initialises the barkeep shift system and ticks payouts.
+    /// </summary>
+    public class BarkeepShiftBehavior : MissionLogic
+    {
+        public static BarkeepShiftBehavior? Instance { get; private set; }
+
+        public override void OnBehaviorInitialize()
+        {
+            base.OnBehaviorInitialize();
+            Instance = this;
+#if SERVER
+            try
+            {
+                var root = TaleWorlds.ModuleManager.ModuleHelper.GetModuleFullPath("PersistentEmpires");
+                BarkeepShiftSystem.Init(root);
+            }
+            catch (Exception e)
+            {
+                Debug.Print("[PEEnhancements] Barkeep init failed: " + e.Message);
+            }
+#endif
+        }
+
+        public override void OnRemoveBehaviour()
+        {
+            base.OnRemoveBehaviour();
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+        }
+
+#if SERVER
+        public override void OnMissionTick(float dt)
+        {
+            base.OnMissionTick(dt);
+            if (!FeatureFlags.EconomyBarkeepEnabled)
+            {
+                return;
+            }
+
+            BarkeepShiftSystem.Tick(dt);
+        }
+
+        /// <summary>
+        /// Helper to toggle a barkeep shift server side via any interaction handler.
+        /// </summary>
+        public bool TryServerToggleViaPeer(NetworkCommunicator peer)
+        {
+            if (!FeatureFlags.EconomyBarkeepEnabled || peer == null)
+            {
+                return false;
+            }
+
+            return BarkeepShiftSystem.ToggleShift(peer);
+        }
+#endif
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepShiftSystem.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepShiftSystem.cs
@@ -1,0 +1,161 @@
+#if SERVER
+using System;
+using System.Collections.Generic;
+using PersistentEmpiresLib;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace PEEnhancements.Economy
+{
+    /// <summary>
+    /// Tracks barkeep shifts and grants periodic payouts while players are on duty.
+    /// </summary>
+    internal static class BarkeepShiftSystem
+    {
+        private sealed class ShiftInfo
+        {
+            public string Id { get; }
+            public WeakReference<NetworkCommunicator> Peer { get; }
+            public DateTime EndsAt { get; set; }
+            public float Accumulator { get; set; }
+
+            public ShiftInfo(string id, NetworkCommunicator peer, TimeSpan duration)
+            {
+                Id = id;
+                Peer = new WeakReference<NetworkCommunicator>(peer);
+                EndsAt = DateTime.UtcNow + duration;
+            }
+        }
+
+        private static readonly Dictionary<string, ShiftInfo> _active = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly object _lock = new();
+
+        private static bool _initialised;
+        private static TimeSpan _shiftDuration = TimeSpan.FromMinutes(30);
+        private static float _payoutIntervalSeconds = 60f;
+        private static int _payoutGold = 50;
+
+        public static void Init(string moduleRootPath)
+        {
+            lock (_lock)
+            {
+                if (_initialised)
+                {
+                    return;
+                }
+
+                _ = moduleRootPath;
+                // Use configuration values if available.
+                _shiftDuration = TimeSpan.FromMinutes(Math.Max(1, FeatureFlags.EconomyBarkeepShiftMinutes));
+                _payoutIntervalSeconds = Math.Max(5, FeatureFlags.EconomyBarkeepPayoutIntervalSeconds);
+                _payoutGold = Math.Max(0, FeatureFlags.EconomyBarkeepPayoutGold);
+                _initialised = true;
+                Debug.Print($"[PEEnhancements] Barkeep system ready (duration={_shiftDuration.TotalMinutes}m, interval={_payoutIntervalSeconds}s, payout={_payoutGold}).");
+            }
+        }
+
+        public static void Tick(float dt)
+        {
+            if (!_initialised)
+            {
+                return;
+            }
+
+            List<string> expired = null;
+
+            lock (_lock)
+            {
+                if (_active.Count == 0)
+                {
+                    return;
+                }
+
+                var now = DateTime.UtcNow;
+                foreach (var kvp in _active)
+                {
+                    var shift = kvp.Value;
+
+                    if (shift.EndsAt <= now)
+                    {
+                        if (expired == null)
+                        {
+                            expired = new List<string>();
+                        }
+                        expired.Add(kvp.Key);
+                        continue;
+                    }
+
+                    if (!shift.Peer.TryGetTarget(out var peer) || peer == null || !peer.IsConnectionActive)
+                    {
+                        if (expired == null)
+                        {
+                            expired = new List<string>();
+                        }
+                        expired.Add(kvp.Key);
+                        continue;
+                    }
+
+                    shift.Accumulator += dt;
+                    if (shift.Accumulator >= _payoutIntervalSeconds)
+                    {
+                        shift.Accumulator -= _payoutIntervalSeconds;
+                        AwardPayout(peer);
+                    }
+                }
+
+                if (expired != null)
+                {
+                    foreach (var key in expired)
+                    {
+                        _active.Remove(key);
+                        Debug.Print($"[PEEnhancements] Barkeep shift finished for {key}.");
+                    }
+                }
+            }
+        }
+
+        public static bool ToggleShift(NetworkCommunicator peer)
+        {
+            if (!_initialised || peer == null)
+            {
+                return false;
+            }
+
+            var id = GetPeerIdentifier(peer);
+            lock (_lock)
+            {
+                if (_active.Remove(id))
+                {
+                    Debug.Print($"[PEEnhancements] Barkeep shift stopped for {id}.");
+                    return false;
+                }
+
+                _active[id] = new ShiftInfo(id, peer, _shiftDuration);
+                Debug.Print($"[PEEnhancements] Barkeep shift started for {id}.");
+                return true;
+            }
+        }
+
+        private static void AwardPayout(NetworkCommunicator peer)
+        {
+            if (_payoutGold <= 0)
+            {
+                return;
+            }
+
+            var representative = peer.GetComponent<PersistentEmpireRepresentative>();
+            if (representative == null)
+            {
+                return;
+            }
+
+            representative.GoldGain(_payoutGold);
+        }
+
+        private static string GetPeerIdentifier(NetworkCommunicator peer)
+        {
+            return peer.UserName ?? peer.VirtualPlayer?.ToString() ?? peer.ToString();
+        }
+    }
+}
+#endif

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/TavernUiPromptBehavior.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/TavernUiPromptBehavior.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Linq;
+using TaleWorlds.Engine;
+using TaleWorlds.InputSystem;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace PEEnhancements.Economy
+{
+    /// <summary>
+    /// Client side prompts and helper interactions for barkeep/tavern areas.
+    /// </summary>
+    public class TavernUiPromptBehavior : MissionLogic
+    {
+        public static TavernUiPromptBehavior? Instance { get; private set; }
+
+        private GameEntity[] _spots = Array.Empty<GameEntity>();
+        private float _lastMsgAt;
+
+        private const float PromptIntervalSeconds = 2.5f;
+        private const float PromptRange = 5.0f;
+
+        public override void OnBehaviorInitialize()
+        {
+            base.OnBehaviorInitialize();
+            Instance = this;
+        }
+
+        public override void OnRemoveBehaviour()
+        {
+            base.OnRemoveBehaviour();
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+        }
+
+        public override void AfterStart()
+        {
+            base.AfterStart();
+#if CLIENT
+            try
+            {
+                var areas = Mission.Current?.Scene?.FindEntitiesWithTag("tavern_area")?.ToArray() ?? Array.Empty<GameEntity>();
+                var counters = Mission.Current?.Scene?.FindEntitiesWithTag("tavern_counter")?.ToArray() ?? Array.Empty<GameEntity>();
+                _spots = areas.Concat(counters).Where(e => e != null).Distinct().ToArray();
+            }
+            catch
+            {
+                _spots = Array.Empty<GameEntity>();
+            }
+#endif
+        }
+
+        public override void OnMissionTick(float dt)
+        {
+            base.OnMissionTick(dt);
+#if CLIENT
+            if (!FeatureFlags.EconomyBarkeepEnabled)
+            {
+                return;
+            }
+
+            var peer = GameNetwork.MyPeer;
+            var agent = Mission.MainAgent;
+            if (peer == null || agent == null || !agent.IsActive())
+            {
+                return;
+            }
+
+            var now = MissionTime.Now.ToSeconds;
+            var near = IsNearTavern(agent);
+            if (near && now >= _lastMsgAt + PromptIntervalSeconds)
+            {
+                InformationManager.DisplayMessage(new InformationMessage(
+                    "Taverne: [E] Schicht starten/stoppen • [T] Trinkgeld geben",
+                    Color.FromUint(0xFF8BC34Au)));
+                _lastMsgAt = now;
+            }
+
+            if (!near)
+            {
+                return;
+            }
+
+            if (Input.IsKeyReleased(InputKey.E))
+            {
+                TryToggleShiftClientNotify();
+            }
+
+            if (Input.IsKeyReleased(InputKey.T))
+            {
+                InformationManager.DisplayMessage(new InformationMessage(
+                    "Trinkgeld: Nutze /tip <Barkeeper> <Betrag> oder euer Interaktionsmenü.",
+                    Color.FromUint(0xFFFFC107u)));
+            }
+#endif
+        }
+
+        private bool IsNearTavern(Agent agent)
+        {
+            if (_spots == null || _spots.Length == 0)
+            {
+                return false;
+            }
+
+            var position = agent.Position;
+            foreach (var entity in _spots)
+            {
+                try
+                {
+                    if (entity == null)
+                    {
+                        continue;
+                    }
+
+                    if (entity.GlobalPosition.Distance(position) <= PromptRange)
+                    {
+                        return true;
+                    }
+                }
+                catch
+                {
+                    // ignored
+                }
+            }
+
+            return false;
+        }
+
+        private void TryToggleShiftClientNotify()
+        {
+            InformationManager.DisplayMessage(new InformationMessage(
+                "Schicht-Toggle angefragt …",
+                Color.FromUint(0xFF03A9F4u)));
+            // Network message hook can be added here once available.
+        }
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/FeatureFlags.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/FeatureFlags.cs
@@ -31,5 +31,9 @@ namespace PEEnhancements
         public static bool PropertyEnabled => Current.Property.Enabled;
         public static bool HuntingOnlyHunterBowMeat => Current.Hunting.OnlyHunterBowMeat;
         public static bool EconomyJobsEnabled => Current.Economy.Jobs.Enabled;
+        public static bool EconomyBarkeepEnabled => Current.Economy.Barkeep.Enabled;
+        public static int EconomyBarkeepPayoutGold => Current.Economy.Barkeep.PayoutGold;
+        public static int EconomyBarkeepPayoutIntervalSeconds => Current.Economy.Barkeep.PayoutIntervalSeconds;
+        public static int EconomyBarkeepShiftMinutes => Current.Economy.Barkeep.ShiftMinutes;
     }
 }

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/PeSettings.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/PeSettings.cs
@@ -52,9 +52,19 @@ namespace PEEnhancements
         public class EconomySettings
         {
             [JsonPropertyName("jobs")] public JobsSettings Jobs { get; set; } = new();
+            [JsonPropertyName("barkeep")] public BarkeepSettings Barkeep { get; set; } = new();
+
             public class JobsSettings
             {
                 [JsonPropertyName("enabled")] public bool Enabled { get; set; } = false;
+            }
+
+            public class BarkeepSettings
+            {
+                [JsonPropertyName("enabled")] public bool Enabled { get; set; } = false;
+                [JsonPropertyName("payoutGold")] public int PayoutGold { get; set; } = 45;
+                [JsonPropertyName("payoutIntervalSeconds")] public int PayoutIntervalSeconds { get; set; } = 60;
+                [JsonPropertyName("shiftMinutes")] public int ShiftMinutes { get; set; } = 30;
             }
         }
 

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PersistentEmpiresMission/MissionBehaviors/AgentHungerBehavior.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PersistentEmpiresMission/MissionBehaviors/AgentHungerBehavior.cs
@@ -184,10 +184,25 @@ namespace PersistentEmpiresLib.PersistentEmpiresMission.MissionBehaviors
             {
                 Mission.Current?.AddMissionBehavior(new PEEnhancements.PropertyMvpBehavior());
             }
+            if (PEEnhancements.Economy.BarkeepShiftBehavior.Instance == null)
+            {
+                Mission.Current?.AddMissionBehavior(new PEEnhancements.Economy.BarkeepShiftBehavior());
+            }
             // Admin/Incidents initialisieren
             if (PEEnhancements.AdminKulanzBehavior.Instance == null)
             {
                 Mission.Current?.AddMissionBehavior(new PEEnhancements.AdminKulanzBehavior());
+            }
+        }
+#endif
+
+#if CLIENT
+        public override void OnMissionTick(float dt)
+        {
+            base.OnMissionTick(dt);
+            if (PEEnhancements.Economy.TavernUiPromptBehavior.Instance == null)
+            {
+                Mission.Current?.AddMissionBehavior(new PEEnhancements.Economy.TavernUiPromptBehavior());
             }
         }
 #endif

--- a/PersistentEmpiresLib/PersistentEmpiresLib/pe.settings.json
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/pe.settings.json
@@ -6,5 +6,13 @@
   "medic": { "enabled": true, "cooldownSeconds": 180 },
   "property": { "enabled": true },
   "hunting": { "onlyHunterBowMeat": true },
-  "economy": { "jobs": { "enabled": false } }
+  "economy": {
+    "jobs": { "enabled": false },
+    "barkeep": {
+      "enabled": false,
+      "payoutGold": 45,
+      "payoutIntervalSeconds": 60,
+      "shiftMinutes": 30
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add a client-side mission behavior that surfaces tavern prompts and handles interact key guidance
- introduce a server barkeep shift mission behavior with payout tracking backed by a configurable system
- expose barkeep feature toggles/settings and hook both behaviors into the mission bootstrap sequence

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd356d09a08332a21010b6edbd1e69