### PR TITLE
feat(pe): network bridge for barkeep toggle and tip register (client->server)

### DIFF
--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepNetBridgeBehavior.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepNetBridgeBehavior.cs
@@ -1,0 +1,68 @@
+using PEEnhancements.Economy.Net;
+using PEEnhancements;
+using TaleWorlds.MountAndBlade;
+
+namespace PEEnhancements.Economy
+{
+    /// <summary>
+    /// Mission network bridge that registers the server handlers for barkeep-related network messages
+    /// and executes the economy actions on the server side.
+    /// </summary>
+    public sealed class BarkeepNetBridgeBehavior : MissionNetwork
+    {
+        public static BarkeepNetBridgeBehavior? Instance { get; private set; }
+
+        public override void OnBehaviorInitialize()
+        {
+            base.OnBehaviorInitialize();
+            Instance = this;
+        }
+
+        public override void OnRemoveBehavior()
+        {
+            base.OnRemoveBehavior();
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+        }
+
+        protected override void AddRemoveMessageHandlers(GameNetwork.NetworkMessageHandlerRegistererContainer registerer)
+        {
+            if (!GameNetwork.IsServer)
+            {
+                return;
+            }
+
+            registerer.Register<MsgBarkeepToggle>(HandleBarkeepToggleFromClient);
+            registerer.Register<MsgTipRegister>(HandleTipRegisterFromClient);
+        }
+
+        private bool HandleBarkeepToggleFromClient(NetworkCommunicator fromPeer, MsgBarkeepToggle _)
+        {
+            if (!FeatureFlags.EconomyBarkeepEnabled || fromPeer == null)
+            {
+                return true;
+            }
+
+            return BarkeepShiftBehavior.Instance?.TryServerToggleViaPeer(fromPeer) ?? true;
+        }
+
+        private bool HandleTipRegisterFromClient(NetworkCommunicator fromPeer, MsgTipRegister msg)
+        {
+            if (!FeatureFlags.EconomyBarkeepEnabled || fromPeer == null)
+            {
+                return true;
+            }
+
+            if (msg.Amount <= 0 || string.IsNullOrWhiteSpace(msg.BarkeepId))
+            {
+                return true;
+            }
+
+            string payerId = fromPeer.UserName ?? fromPeer.VirtualPlayer?.ToString() ?? fromPeer.ToString();
+            BarkeepShiftSystem.RegisterTip(payerId, msg.BarkeepId, msg.Amount);
+            return true;
+        }
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepShiftBehavior.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepShiftBehavior.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using TaleWorlds.MountAndBlade;
+
+namespace PEEnhancements.Economy
+{
+    /// <summary>
+    /// Mission behavior that keeps track of barkeep shifts on the server.
+    /// </summary>
+    public sealed class BarkeepShiftBehavior : MissionBehavior
+    {
+        private readonly Dictionary<string, MissionPeer> _activeBarkeepers = new Dictionary<string, MissionPeer>();
+
+        public static BarkeepShiftBehavior? Instance { get; private set; }
+
+        public override MissionBehaviorType BehaviorType => MissionBehaviorType.Other;
+
+        public override void OnBehaviorInitialize()
+        {
+            base.OnBehaviorInitialize();
+            Instance = this;
+        }
+
+        public override void OnRemoveBehavior()
+        {
+            base.OnRemoveBehavior();
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+
+            _activeBarkeepers.Clear();
+        }
+
+        /// <summary>
+        /// Server side helper that toggles the shift of the provided peer.
+        /// </summary>
+        public bool TryServerToggleViaPeer(NetworkCommunicator peer)
+        {
+            if (!GameNetwork.IsServer || peer == null)
+            {
+                return false;
+            }
+
+            string barkeepId = peer.UserName ?? peer.VirtualPlayer?.ToString() ?? peer.ToString();
+
+            if (_activeBarkeepers.ContainsKey(barkeepId))
+            {
+                _activeBarkeepers.Remove(barkeepId);
+                BarkeepShiftSystem.EndShift(barkeepId);
+                return true;
+            }
+
+            MissionPeer missionPeer = peer.GetComponent<MissionPeer>();
+            if (missionPeer != null)
+            {
+                _activeBarkeepers[barkeepId] = missionPeer;
+            }
+
+            BarkeepShiftSystem.BeginOrExtendShift(barkeepId);
+            return true;
+        }
+
+        public bool IsOnShift(string barkeepId) => _activeBarkeepers.ContainsKey(barkeepId);
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepShiftSystem.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepShiftSystem.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using TaleWorlds.Library;
+
+namespace PEEnhancements.Economy
+{
+    /// <summary>
+    /// Shared system logic that keeps track of barkeep shifts and registered tips.
+    /// </summary>
+    public static class BarkeepShiftSystem
+    {
+        private sealed class BarkeepShiftState
+        {
+            private readonly HashSet<string> _uniquePayers = new HashSet<string>();
+
+            public string BarkeepId { get; }
+
+            public DateTime StartedAt { get; private set; }
+
+            public DateTime LastActivityUtc { get; private set; }
+
+            public int TotalTipAmount { get; private set; }
+
+            public BarkeepShiftState(string barkeepId)
+            {
+                BarkeepId = barkeepId;
+                StartedAt = DateTime.UtcNow;
+                LastActivityUtc = StartedAt;
+            }
+
+            public void RefreshShift()
+            {
+                if (StartedAt == DateTime.MinValue)
+                {
+                    StartedAt = DateTime.UtcNow;
+                }
+
+                LastActivityUtc = DateTime.UtcNow;
+            }
+
+            public void RegisterTip(string payerId, int amount)
+            {
+                TotalTipAmount += Math.Max(0, amount);
+                LastActivityUtc = DateTime.UtcNow;
+                if (!string.IsNullOrEmpty(payerId))
+                {
+                    _uniquePayers.Add(payerId);
+                }
+            }
+        }
+
+        private static readonly Dictionary<string, BarkeepShiftState> ActiveShifts = new Dictionary<string, BarkeepShiftState>();
+
+        private static readonly object SyncRoot = new object();
+
+        /// <summary>
+        /// Starts a new shift for the specified barkeep or refreshes the current one.
+        /// </summary>
+        public static void BeginOrExtendShift(string barkeepId)
+        {
+            if (string.IsNullOrWhiteSpace(barkeepId))
+            {
+                return;
+            }
+
+            lock (SyncRoot)
+            {
+                if (!ActiveShifts.TryGetValue(barkeepId, out BarkeepShiftState state))
+                {
+                    state = new BarkeepShiftState(barkeepId);
+                    ActiveShifts[barkeepId] = state;
+                    Debug.Print($"[PE] Barkeep shift started for {barkeepId}.");
+                }
+                else
+                {
+                    state.RefreshShift();
+                    Debug.Print($"[PE] Barkeep shift refreshed for {barkeepId}.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Ends the running shift for the specified barkeep.
+        /// </summary>
+        public static void EndShift(string barkeepId)
+        {
+            if (string.IsNullOrWhiteSpace(barkeepId))
+            {
+                return;
+            }
+
+            lock (SyncRoot)
+            {
+                if (ActiveShifts.Remove(barkeepId))
+                {
+                    Debug.Print($"[PE] Barkeep shift ended for {barkeepId}.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Registers a tip for the target barkeep. If the barkeep is not currently on shift,
+        /// the shift will be started automatically.
+        /// </summary>
+        public static void RegisterTip(string payerId, string barkeepId, int amount)
+        {
+            if (string.IsNullOrWhiteSpace(barkeepId) || amount <= 0)
+            {
+                return;
+            }
+
+            lock (SyncRoot)
+            {
+                if (!ActiveShifts.TryGetValue(barkeepId, out BarkeepShiftState state))
+                {
+                    state = new BarkeepShiftState(barkeepId);
+                    ActiveShifts[barkeepId] = state;
+                    Debug.Print($"[PE] Barkeep shift auto-started for {barkeepId} due to tip.");
+                }
+
+                state.RegisterTip(payerId, amount);
+                Debug.Print($"[PE] Tip registered for {barkeepId}: {amount} denars by {payerId}.");
+            }
+        }
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/Net/MsgBarkeepToggle.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/Net/MsgBarkeepToggle.cs
@@ -1,0 +1,27 @@
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Network.Messages;
+
+namespace PEEnhancements.Economy.Net
+{
+    /// <summary>
+    /// Client -> Server message requesting to toggle the barkeep shift.
+    /// Payload free; identity is derived from the sending <see cref="NetworkCommunicator"/>.
+    /// </summary>
+    public sealed class MsgBarkeepToggle : GameNetworkMessage
+    {
+        protected override bool OnRead()
+        {
+            // No payload to read.
+            return true;
+        }
+
+        protected override void OnWrite()
+        {
+            // No payload to write.
+        }
+
+        protected override MultiplayerMessageFilter OnGetLogFilter() => MultiplayerMessageFilter.Mission;
+
+        protected override string OnGetLogFormat() => "[PE] BarkeepToggle request";
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/Net/MsgTipRegister.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/Net/MsgTipRegister.cs
@@ -1,0 +1,44 @@
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Network.Messages;
+
+namespace PEEnhancements.Economy.Net
+{
+    /// <summary>
+    /// Client -> Server message registering a tip for a barkeep.
+    /// </summary>
+    public sealed class MsgTipRegister : GameNetworkMessage
+    {
+        public string BarkeepId { get; private set; } = string.Empty;
+
+        public int Amount { get; private set; }
+
+        public MsgTipRegister()
+        {
+        }
+
+        public MsgTipRegister(string barkeepId, int amount)
+        {
+            BarkeepId = barkeepId ?? string.Empty;
+            Amount = amount;
+        }
+
+        protected override bool OnRead()
+        {
+            bool bufferReadValid = true;
+            BarkeepId = ReadStringFromPacket(ref bufferReadValid);
+            Amount = ReadIntFromPacket(CompressionBasic.Int32CompressionInfo, ref bufferReadValid);
+            return bufferReadValid;
+        }
+
+        protected override void OnWrite()
+        {
+            WriteStringToPacket(BarkeepId);
+            WriteIntToPacket(Amount, CompressionBasic.Int32CompressionInfo);
+        }
+
+        protected override MultiplayerMessageFilter OnGetLogFilter() => MultiplayerMessageFilter.Mission;
+
+        protected override string OnGetLogFormat() => $"[PE] TipRegister {BarkeepId}:{Amount}";
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/TavernUiPromptBehavior.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/TavernUiPromptBehavior.cs
@@ -1,0 +1,71 @@
+using PEEnhancements.Economy.Net;
+using PEEnhancements;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace PEEnhancements.Economy
+{
+    /// <summary>
+    /// Client-side helper behavior that allows requesting barkeep actions from the UI.
+    /// </summary>
+    public sealed class TavernUiPromptBehavior : MissionBehavior
+    {
+        public static TavernUiPromptBehavior? Instance { get; private set; }
+
+        public override MissionBehaviorType BehaviorType => MissionBehaviorType.Other;
+
+        public override void OnBehaviorInitialize()
+        {
+            base.OnBehaviorInitialize();
+            Instance = this;
+        }
+
+        public override void OnRemoveBehavior()
+        {
+            base.OnRemoveBehavior();
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+        }
+
+        /// <summary>
+        /// Shows a local notification and, if appropriate, asks the server to toggle the shift.
+        /// </summary>
+        public void TryToggleShiftClientNotify()
+        {
+            if (!FeatureFlags.EconomyBarkeepEnabled)
+            {
+                return;
+            }
+
+            InformationManager.DisplayMessage(new InformationMessage("Schicht-Toggle angefragt …", Color.FromUint(0xFF03A9F4)));
+            if (GameNetwork.IsClient)
+            {
+                GameNetwork.BeginModuleEventAsClient();
+                GameNetwork.WriteMessage(new MsgBarkeepToggle());
+                GameNetwork.EndModuleEventAsClient();
+            }
+        }
+
+        /// <summary>
+        /// Sends a tip registration request to the server.
+        /// </summary>
+        public void RegisterTip(string barkeepId, int amount)
+        {
+            if (!FeatureFlags.EconomyBarkeepEnabled)
+            {
+                return;
+            }
+
+            if (!GameNetwork.IsClient || string.IsNullOrWhiteSpace(barkeepId) || amount <= 0)
+            {
+                return;
+            }
+
+            GameNetwork.BeginModuleEventAsClient();
+            GameNetwork.WriteMessage(new MsgTipRegister(barkeepId, amount));
+            GameNetwork.EndModuleEventAsClient();
+        }
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/FeatureFlags.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/FeatureFlags.cs
@@ -1,0 +1,14 @@
+namespace PEEnhancements
+{
+    /// <summary>
+    /// Feature toggles for experimental PE enhancements.
+    /// </summary>
+    public static class FeatureFlags
+    {
+        /// <summary>
+        /// Controls whether the enhanced barkeep economy features are enabled.
+        /// Defaults to <c>true</c>, but can be changed at runtime by other systems if required.
+        /// </summary>
+        public static bool EconomyBarkeepEnabled { get; set; } = true;
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PersistentEmpiresMission/MissionBehaviors/AgentHungerBehavior.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PersistentEmpiresMission/MissionBehaviors/AgentHungerBehavior.cs
@@ -12,6 +12,8 @@ using TaleWorlds.ModuleManager;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.ObjectSystem;
 using static TaleWorlds.Library.Debug;
+using PEEnhancements;
+using PEEnhancements.Economy;
 
 namespace PersistentEmpiresLib.PersistentEmpiresMission.MissionBehaviors
 {
@@ -190,6 +192,26 @@ namespace PersistentEmpiresLib.PersistentEmpiresMission.MissionBehaviors
         {
             base.OnBehaviorInitialize();
             this.AddRemoveMessageHandlers(GameNetwork.NetworkMessageHandlerRegisterer.RegisterMode.Add);
+            if (FeatureFlags.EconomyBarkeepEnabled)
+            {
+                if (GameNetwork.IsClient && TavernUiPromptBehavior.Instance == null)
+                {
+                    Mission.Current?.AddMissionBehavior(new TavernUiPromptBehavior());
+                }
+
+                if (GameNetwork.IsServer)
+                {
+                    if (BarkeepShiftBehavior.Instance == null)
+                    {
+                        Mission.Current?.AddMissionBehavior(new BarkeepShiftBehavior());
+                    }
+
+                    if (BarkeepNetBridgeBehavior.Instance == null)
+                    {
+                        Mission.Current?.AddMissionBehavior(new BarkeepNetBridgeBehavior());
+                    }
+                }
+            }
             if (GameNetwork.IsServer)
             {
                 this.HungerInterval = ConfigManager.GetIntConfig("HungerInterval", 72); // 60 secs


### PR DESCRIPTION
## Summary
- add feature flag scaffolding and client-side behavior to request barkeep actions from the UI
- implement server network bridge plus shift/tip management helpers for barkeep economy
- register the new behaviors during mission initialization so client and server wire up the handlers

## Testing
- `dotnet build PersistentEmpiresLib/PersistentEmpiresLib.sln` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd67b6c7c08332a288c5466c529b7b