### PR TITLE
feat(pe): network bridge for barkeep toggle and tip register (client->server)

### DIFF
--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepNetBridgeBehavior.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepNetBridgeBehavior.cs
@@ -1,0 +1,99 @@
+using TaleWorlds.MountAndBlade;
+using PEEnhancements.Economy.Net;
+
+namespace PEEnhancements.Economy
+{
+    /// <summary>
+    /// Bridges client network messages for the barkeep economy features to the server logic.
+    /// </summary>
+    public class BarkeepNetBridgeBehavior : MissionNetwork
+    {
+        public static BarkeepNetBridgeBehavior? Instance { get; private set; }
+
+        public override void OnBehaviorInitialize()
+        {
+            base.OnBehaviorInitialize();
+            Instance = this;
+        }
+
+        public override void AfterStart()
+        {
+            base.AfterStart();
+            if (!GameNetwork.IsServer)
+            {
+                return;
+            }
+
+            RegisterMessageHandlers(GameNetwork.NetworkMessageHandlerRegisterer.RegisterMode.Add);
+
+            if (Mission.Current != null && Mission.Current.GetMissionBehavior<BarkeepShiftBehavior>() == null)
+            {
+                Mission.Current.AddMissionBehavior(new BarkeepShiftBehavior());
+            }
+        }
+
+        public override void OnRemoveBehavior()
+        {
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+
+            if (GameNetwork.IsServer)
+            {
+                RegisterMessageHandlers(GameNetwork.NetworkMessageHandlerRegisterer.RegisterMode.Remove);
+            }
+
+            base.OnRemoveBehavior();
+        }
+
+        private void RegisterMessageHandlers(GameNetwork.NetworkMessageHandlerRegisterer.RegisterMode mode)
+        {
+            var registerer = new GameNetwork.NetworkMessageHandlerRegisterer(mode);
+            registerer.Register<MsgBarkeepToggle>(HandleBarkeepToggleFromClient);
+            registerer.Register<MsgTipRegister>(HandleTipRegisterFromClient);
+        }
+
+        private bool HandleBarkeepToggleFromClient(NetworkCommunicator fromPeer, MsgBarkeepToggle message)
+        {
+            if (!FeatureFlags.EconomyBarkeepEnabled || fromPeer == null)
+            {
+                return true;
+            }
+
+            return BarkeepShiftBehavior.Instance?.TryServerToggleViaPeer(fromPeer) ?? true;
+        }
+
+        private bool HandleTipRegisterFromClient(NetworkCommunicator fromPeer, MsgTipRegister message)
+        {
+            if (!FeatureFlags.EconomyBarkeepEnabled || fromPeer == null)
+            {
+                return true;
+            }
+
+            if (message.Amount <= 0 || string.IsNullOrWhiteSpace(message.BarkeepId))
+            {
+                return true;
+            }
+
+            string payerId = ResolvePeerId(fromPeer);
+            BarkeepShiftSystem.RegisterTip(payerId, message.BarkeepId, message.Amount);
+            return true;
+        }
+
+        private static string ResolvePeerId(NetworkCommunicator peer)
+        {
+            if (!string.IsNullOrEmpty(peer.UserName))
+            {
+                return peer.UserName;
+            }
+
+            if (peer.VirtualPlayer != null)
+            {
+                return peer.VirtualPlayer.ToString();
+            }
+
+            return peer.ToString();
+        }
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepShiftBehavior.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepShiftBehavior.cs
@@ -1,0 +1,63 @@
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace PEEnhancements.Economy
+{
+    /// <summary>
+    /// Maintains barkeep shift state while a mission is running.
+    /// </summary>
+    public sealed class BarkeepShiftBehavior : MissionBehavior
+    {
+        public static BarkeepShiftBehavior? Instance { get; private set; }
+
+        public override MissionBehaviorType BehaviorType => MissionBehaviorType.Other;
+
+        public override void OnBehaviorInitialize()
+        {
+            base.OnBehaviorInitialize();
+            Instance = this;
+        }
+
+        public override void OnRemoveBehavior()
+        {
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+
+            base.OnRemoveBehavior();
+        }
+
+        /// <summary>
+        /// Server-side entry point that toggles the calling peer's barkeep shift.
+        /// </summary>
+        public bool TryServerToggleViaPeer(NetworkCommunicator peer)
+        {
+            if (!GameNetwork.IsServer || peer == null)
+            {
+                return true;
+            }
+
+            string barkeepId = ResolvePeerId(peer);
+            bool nowOnShift = BarkeepShiftSystem.ToggleShift(barkeepId);
+
+            Debug.Print($"[PE] Barkeep shift toggle via network: {barkeepId} -> {(nowOnShift ? "ON" : "OFF")}", 0, DebugColor.Cyan);
+            return true;
+        }
+
+        private static string ResolvePeerId(NetworkCommunicator peer)
+        {
+            if (!string.IsNullOrWhiteSpace(peer.UserName))
+            {
+                return peer.UserName;
+            }
+
+            if (peer.VirtualPlayer != null)
+            {
+                return peer.VirtualPlayer.ToString();
+            }
+
+            return peer.ToString();
+        }
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepShiftSystem.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/BarkeepShiftSystem.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using TaleWorlds.Library;
+
+namespace PEEnhancements.Economy
+{
+    /// <summary>
+    /// Tracks the state of barkeep shifts and tip amounts server-side.
+    /// </summary>
+    public static class BarkeepShiftSystem
+    {
+        private sealed class BarkeepShiftState
+        {
+            public bool OnShift;
+            public DateTime LastToggleUtc;
+            public int TotalTips;
+            public Dictionary<string, int> TipsByPayer = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static readonly Dictionary<string, BarkeepShiftState> ShiftStates = new Dictionary<string, BarkeepShiftState>(StringComparer.OrdinalIgnoreCase);
+        private static readonly object SyncRoot = new object();
+
+        /// <summary>
+        /// Toggles the shift for the provided barkeep identifier.
+        /// </summary>
+        public static bool ToggleShift(string barkeepId)
+        {
+            if (string.IsNullOrWhiteSpace(barkeepId))
+            {
+                return false;
+            }
+
+            lock (SyncRoot)
+            {
+                var state = GetOrCreateState(barkeepId);
+                state.OnShift = !state.OnShift;
+                state.LastToggleUtc = DateTime.UtcNow;
+                ShiftStates[barkeepId] = state;
+
+                Debug.Print($"[PE] Barkeep shift {(state.OnShift ? "started" : "stopped")}: {barkeepId}", 0, DebugColor.Cyan);
+                return state.OnShift;
+            }
+        }
+
+        /// <summary>
+        /// Registers a tip transfer between a payer and a barkeep.
+        /// </summary>
+        public static void RegisterTip(string payerId, string barkeepId, int amount)
+        {
+            if (string.IsNullOrWhiteSpace(barkeepId) || amount <= 0)
+            {
+                return;
+            }
+
+            lock (SyncRoot)
+            {
+                var state = GetOrCreateState(barkeepId);
+                state.TotalTips += amount;
+                if (!string.IsNullOrWhiteSpace(payerId))
+                {
+                    if (state.TipsByPayer.TryGetValue(payerId, out var current))
+                    {
+                        state.TipsByPayer[payerId] = current + amount;
+                    }
+                    else
+                    {
+                        state.TipsByPayer[payerId] = amount;
+                    }
+                }
+
+                Debug.Print($"[PE] Tip registered for {barkeepId} from {payerId}: {amount}", 0, DebugColor.Cyan);
+            }
+        }
+
+        /// <summary>
+        /// Returns whether the barkeep is currently on shift.
+        /// </summary>
+        public static bool IsOnShift(string barkeepId)
+        {
+            if (string.IsNullOrWhiteSpace(barkeepId))
+            {
+                return false;
+            }
+
+            lock (SyncRoot)
+            {
+                return ShiftStates.TryGetValue(barkeepId, out var state) && state.OnShift;
+            }
+        }
+
+        private static BarkeepShiftState GetOrCreateState(string barkeepId)
+        {
+            if (!ShiftStates.TryGetValue(barkeepId, out var state))
+            {
+                state = new BarkeepShiftState();
+                ShiftStates[barkeepId] = state;
+            }
+
+            return state;
+        }
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/Net/MsgBarkeepToggle.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/Net/MsgBarkeepToggle.cs
@@ -3,27 +3,29 @@ using TaleWorlds.MountAndBlade.Network.Messages;
 
 namespace PEEnhancements.Economy.Net
 {
+    /// <summary>
+    /// Client-&gt;Server: Toggle the barkeep shift for the requesting peer.
+    /// </summary>
     [DefineGameNetworkMessageTypeForMod(GameNetworkMessageSendType.FromClient)]
     public sealed class MsgBarkeepToggle : GameNetworkMessage
     {
-        protected override MultiplayerMessageFilter OnGetLogFilter()
-        {
-            return MultiplayerMessageFilter.MissionObjects;
-        }
-
-        protected override string OnGetLogFormat()
-        {
-            return "Barkeep shift toggle request";
-        }
-
         protected override bool OnRead()
         {
-            bool bufferReadValid = true;
-            return bufferReadValid;
+            return true;
         }
 
         protected override void OnWrite()
         {
+        }
+
+        protected override MultiplayerMessageFilter OnGetLogFilter()
+        {
+            return MultiplayerMessageFilter.Mission;
+        }
+
+        protected override string OnGetLogFormat()
+        {
+            return "[PE] BarkeepToggle request";
         }
     }
 }

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/Net/MsgTipRegister.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/Economy/Net/MsgTipRegister.cs
@@ -4,6 +4,9 @@ using TaleWorlds.MountAndBlade.Network.Messages;
 
 namespace PEEnhancements.Economy.Net
 {
+    /// <summary>
+    /// Client-&gt;Server: Register a tip for a barkeep.
+    /// </summary>
     [DefineGameNetworkMessageTypeForMod(GameNetworkMessageSendType.FromClient)]
     public sealed class MsgTipRegister : GameNetworkMessage
     {
@@ -13,36 +16,36 @@ namespace PEEnhancements.Economy.Net
 
         public MsgTipRegister(string barkeepId, int amount)
         {
-            BarkeepId = barkeepId;
+            BarkeepId = barkeepId ?? string.Empty;
             Amount = amount;
         }
 
-        public string BarkeepId { get; private set; }
+        public string BarkeepId { get; private set; } = string.Empty;
 
         public int Amount { get; private set; }
-
-        protected override MultiplayerMessageFilter OnGetLogFilter()
-        {
-            return MultiplayerMessageFilter.MissionObjects;
-        }
-
-        protected override string OnGetLogFormat()
-        {
-            return "Register tip";
-        }
 
         protected override bool OnRead()
         {
             bool bufferReadValid = true;
-            BarkeepId = GameNetworkMessage.ReadStringFromPacket(ref bufferReadValid);
-            Amount = GameNetworkMessage.ReadIntFromPacket(new CompressionInfo.Integer(0, int.MaxValue, true), ref bufferReadValid);
+            BarkeepId = ReadStringFromPacket(ref bufferReadValid);
+            Amount = ReadIntFromPacket(CompressionBasic.Int32CompressionInfo, ref bufferReadValid);
             return bufferReadValid;
         }
 
         protected override void OnWrite()
         {
-            GameNetworkMessage.WriteStringToPacket(BarkeepId);
-            GameNetworkMessage.WriteIntToPacket(Amount, new CompressionInfo.Integer(0, int.MaxValue, true));
+            WriteStringToPacket(BarkeepId);
+            WriteIntToPacket(Amount, CompressionBasic.Int32CompressionInfo);
+        }
+
+        protected override MultiplayerMessageFilter OnGetLogFilter()
+        {
+            return MultiplayerMessageFilter.Mission;
+        }
+
+        protected override string OnGetLogFormat()
+        {
+            return $"[PE] TipRegister {BarkeepId}:{Amount}";
         }
     }
 }

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/FeatureFlags.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PEEnhancements/FeatureFlags.cs
@@ -1,0 +1,13 @@
+namespace PEEnhancements
+{
+    /// <summary>
+    /// Feature flag container for optional Persistent Empires enhancements.
+    /// </summary>
+    public static class FeatureFlags
+    {
+        /// <summary>
+        /// Enables the barkeep economy features (shift toggling, tip registration, etc.).
+        /// </summary>
+        public static bool EconomyBarkeepEnabled { get; set; } = true;
+    }
+}

--- a/PersistentEmpiresLib/PersistentEmpiresLib/PersistentEmpiresMission/MissionBehaviors/AgentHungerBehavior.cs
+++ b/PersistentEmpiresLib/PersistentEmpiresLib/PersistentEmpiresMission/MissionBehaviors/AgentHungerBehavior.cs
@@ -208,6 +208,17 @@ namespace PersistentEmpiresLib.PersistentEmpiresMission.MissionBehaviors
                 this.LoadEatables(module.Id);
             }
 
+#if CLIENT
+            if (Mission.Current != null && Mission.Current.GetMissionBehavior<PEEnhancements.Economy.TavernUiPromptBehavior>() == null)
+            {
+                Mission.Current.AddMissionBehavior(new PEEnhancements.Economy.TavernUiPromptBehavior());
+            }
+#endif
+            if (Mission.Current != null && GameNetwork.IsServer && Mission.Current.GetMissionBehavior<PEEnhancements.Economy.BarkeepNetBridgeBehavior>() == null)
+            {
+                Mission.Current.AddMissionBehavior(new PEEnhancements.Economy.BarkeepNetBridgeBehavior());
+            }
+
         }
 
         public override void OnRemoveBehavior()


### PR DESCRIPTION
## Summary
- add a mission network bridge that registers server-side handlers for barkeep toggle and tip messages and ensures the barkeep shift logic is present
- implement barkeep shift state tracking, tip registration, and a feature flag hook used by the new bridge
- harden the client->server messages and register the new behaviors from the hunger mission setup so both client prompts and server bridge initialize

## Testing
- `dotnet build PersistentEmpiresLib/PersistentEmpiresLib/PersistentEmpiresLib.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cd90b7275483329743cf0b90ecd23c